### PR TITLE
Fix deprecated Iterable import

### DIFF
--- a/pd3f/utils.py
+++ b/pd3f/utils.py
@@ -2,8 +2,7 @@
 """
 
 import json
-from collections import Iterable
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 
 def update_dict(d, u):


### PR DESCRIPTION
The Iterable class should be imported from collections.abc instead.

See https://stackoverflow.com/questions/72032032/importerror-cannot-import-name-iterable-from-collections-in-python